### PR TITLE
✏️ added alternative aws cred file param and source

### DIFF
--- a/tools/sentieon_gvcftyper.cwl
+++ b/tools/sentieon_gvcftyper.cwl
@@ -43,6 +43,9 @@ inputs:
   type: string?
 - id: AWS_SESSION_TOKEN
   type: string?
+- id: aws_creds_export
+  type: File?
+  doc: "File with AWS credentials to source"
 - id: input_gvcf_files
   label: Input GVCFs
   type: File[]?
@@ -67,7 +70,7 @@ inputs:
     position: 1
     shellQuote: false
     valueFrom: |-
-      set -eo pipefail; mkdir input_folder; parallel -P $(inputs.max_downloads) --jl parallel.log --shuf --timeout 1200 --retries 5 bash -c :::: $(self.path) || exit 1; find -type f -name 'sample-*.g.vcf.gz' | sort |
+      set -eo pipefail; $(inputs.aws_creds_export != null ? ". " + inputs.aws_creds_export.path + ";" : "") mkdir input_folder; parallel -P $(inputs.max_downloads) --jl parallel.log --shuf --timeout 1200 --retries 5 bash -c :::: $(self.path) || exit 1; find -type f -name 'sample-*.g.vcf.gz' | sort |
 - id: reference
   label: Reference
   doc: Reference fasta file with associated indexes

--- a/workflow/jointgenotyping-workflow.cwl
+++ b/workflow/jointgenotyping-workflow.cwl
@@ -57,6 +57,9 @@ inputs:
   label: Sentieon license
   doc: License server host and port
   type: string
+- id: aws_creds_export
+  type: File?
+  doc: "File with AWS credentials to source instead of string args"
 - id: AWS_ACCESS_KEY_ID
   type: string?
 - id: AWS_SECRET_ACCESS_KEY
@@ -134,6 +137,8 @@ steps:
     source: gvcf_typer_cpus
   - id: mem_per_job
     source: gvcf_typer_mem
+  - id: aws_creds_export
+    source: aws_creds_export
   - id: AWS_ACCESS_KEY_ID
     source: AWS_ACCESS_KEY_ID
   - id: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Use a file with format:
```
export AWS_ACCESS_KEY_ID={key_id}
export AWS_SECRET_ACCESS_KEY={key{
```
that can be sourced instead of envVar using plain text string.
Sort of successful here:
https://cavatica.sbgenomics.com/u/d3b-bixu/kf-sentieon-join-cohort-genotyping-dev/tasks/b10c638f-4901-47d5-8f2a-249e4df5f4d3/
files downloaded, but then hung